### PR TITLE
WIP: Add gcal support to live page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,6 +2,8 @@ require('dotenv').config({
     path: `.env.${process.env.NODE_ENV}`,
 });
 
+const settings = require('./src/data/site.json');
+
 // const contentfulConfig = {
 //     spaceId: process.env.CONTENTFUL_SPACE_ID,
 //     accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
@@ -24,9 +26,7 @@ require('dotenv').config({
 // }
 
 module.exports = {
-    siteMetadata: {
-        title: 'HackTheMidlands',
-    },
+    siteMetadata: settings.meta,
     pathPrefix: '/gatsby-contentful-starter',
     plugins: [
         'gatsby-transformer-remark',
@@ -49,7 +49,7 @@ module.exports = {
         {
             resolve: `gatsby-plugin-google-analytics`,
             options: {
-                trackingId: "UA-177286572-1",
+                trackingId: 'UA-177286572-1',
             },
         },
         `gatsby-optional-chaining`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6475,6 +6475,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -19169,6 +19174,14 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "swr": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.3.6.tgz",
+      "integrity": "sha512-LHbX9vVQSW8Kgyr86zz2fVVKmmT13qxB61uXuUAg6NT4cGu6afzAzT2SVCGEh8pJAD2o8NTZMgclIUxIAbvk7Q==",
+      "requires": {
+        "dequal": "2.0.2"
       }
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-helmet": "^5.2.1",
     "react-masonry-component": "^6.2.1",
     "sharp": "^0.25.1",
+    "swr": "^0.3.6",
     "uniqid": "^5.2.0"
   },
   "devDependencies": {

--- a/src/components/live-countdown/live-countdown.jsx
+++ b/src/components/live-countdown/live-countdown.jsx
@@ -54,7 +54,7 @@ export const LiveCountdown = ({ countdownToDate }) => {
   } = data.site.siteMetadata
 
   const { data: times } = useSWR(
-    "event-data",
+    "event-countdown",
     async () => {
       let resp = await fetch(
             googleCalendarURL(

--- a/src/components/live-countdown/live-countdown.jsx
+++ b/src/components/live-countdown/live-countdown.jsx
@@ -4,6 +4,8 @@ import { Grid, Row, Col } from 'react-flexbox-grid';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import { graphql, useStaticQuery } from "gatsby"
+import useSWR from "swr"
 
 // Helper imports
 
@@ -14,6 +16,14 @@ import styles from './live-countdown.module.scss';
 
 // Image imports
 
+
+function googleCalendarURL(id, eventId, apiKey) {
+  return new URL(
+    `https://www.googleapis.com/calendar/v3/calendars/${id}/events/${eventId}?key=${apiKey}`
+  )
+}
+
+
 /**
  * Live countdown components
  * @param props
@@ -21,6 +31,57 @@ import styles from './live-countdown.module.scss';
  * @constructor
  */
 export const LiveCountdown = ({ countdownToDate }) => {
+      const data = useStaticQuery(graphql`
+    query LiveCountdownQuery {
+      site {
+        siteMetadata {
+          eventStartString: eventStart
+          eventEndString: eventEnd
+          googleCalendarId: countdownCalendarId
+          googleCalendarApiKey: googleCalendarApiKey
+          googleCalendarEventID: googleCalendarEventID
+        }
+      }
+    }
+  `)
+
+  const {
+    eventStartString,
+    eventEndString,
+    googleCalendarApiKey, // gcp key restricted to the calendar api and requests from https://hackthemidlands.com
+    googleCalendarId,
+    googleCalendarEventID,
+  } = data.site.siteMetadata
+
+  const { data: times } = useSWR(
+    "event-data",
+    async () => {
+      let resp = await fetch(
+            googleCalendarURL(
+              googleCalendarId,
+              googleCalendarEventID,
+              googleCalendarApiKey
+            )
+      )
+      if (resp.ok) {
+        let json = await resp.json()
+        return {
+          start: moment(json.start.dateTime),
+          end: moment(json.end.dateTime),
+        }
+      } else {
+        return { start: moment(eventStartString), end: moment(eventEndString) }
+      }
+    },
+    {
+      initialData: {
+        start: moment(eventStartString),
+        end: moment(eventEndString),
+      },
+      revalidateOnMount: true,
+    }
+  )
+
     const [countdown, setCountdown] = useState({
         days: 0,
         hours: 0,
@@ -31,7 +92,8 @@ export const LiveCountdown = ({ countdownToDate }) => {
     const calculateCountdownValues = () => {
         const current = moment();
         const currentUnix = current.unix();
-        const diffTime = countdownToDate.unix() - currentUnix;
+        
+        const diffTime = currentUnix < times.start.unix() ? times.start.unix() - currentUnix : times.end.unix() - currentUnix;
         const duration = moment.duration(diffTime, 'seconds');
         setCountdown({
             days: duration.days(),
@@ -47,7 +109,7 @@ export const LiveCountdown = ({ countdownToDate }) => {
         return () => {
             clearInterval(countdownInterval);
         };
-    }, [countdownToDate]);
+    }, [countdownToDate, times]);
 
     return (
         <Grid fluid>

--- a/src/components/live-countdown/live-countdown.jsx
+++ b/src/components/live-countdown/live-countdown.jsx
@@ -4,8 +4,8 @@ import { Grid, Row, Col } from 'react-flexbox-grid';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { graphql, useStaticQuery } from "gatsby"
-import useSWR from "swr"
+import { graphql, useStaticQuery } from 'gatsby';
+import useSWR from 'swr';
 
 // Helper imports
 
@@ -18,9 +18,9 @@ import styles from './live-countdown.module.scss';
 
 
 function googleCalendarURL(id, eventId, apiKey) {
-  return new URL(
-    `https://www.googleapis.com/calendar/v3/calendars/${id}/events/${eventId}?key=${apiKey}`
-  )
+    return new URL(
+        `https://www.googleapis.com/calendar/v3/calendars/${id}/events/${eventId}?key=${apiKey}`,
+    );
 }
 
 
@@ -31,7 +31,7 @@ function googleCalendarURL(id, eventId, apiKey) {
  * @constructor
  */
 export const LiveCountdown = ({ countdownToDate }) => {
-      const data = useStaticQuery(graphql`
+    const data = useStaticQuery(graphql`
     query LiveCountdownQuery {
       site {
         siteMetadata {
@@ -43,44 +43,43 @@ export const LiveCountdown = ({ countdownToDate }) => {
         }
       }
     }
-  `)
+  `);
 
-  const {
-    eventStartString,
-    eventEndString,
-    googleCalendarApiKey, // gcp key restricted to the calendar api and requests from https://hackthemidlands.com
-    googleCalendarId,
-    googleCalendarEventID,
-  } = data.site.siteMetadata
+    const {
+        eventStartString,
+        eventEndString,
+        googleCalendarApiKey, // gcp key restricted to the calendar api and requests from https://hackthemidlands.com
+        googleCalendarId,
+        googleCalendarEventID,
+    } = data.site.siteMetadata;
 
-  const { data: times } = useSWR(
-    "event-countdown",
-    async () => {
-      let resp = await fetch(
-            googleCalendarURL(
-              googleCalendarId,
-              googleCalendarEventID,
-              googleCalendarApiKey
-            )
-      )
-      if (resp.ok) {
-        let json = await resp.json()
-        return {
-          start: moment(json.start.dateTime),
-          end: moment(json.end.dateTime),
-        }
-      } else {
-        return { start: moment(eventStartString), end: moment(eventEndString) }
-      }
-    },
-    {
-      initialData: {
-        start: moment(eventStartString),
-        end: moment(eventEndString),
-      },
-      revalidateOnMount: true,
-    }
-  )
+    const { data: times } = useSWR(
+        'event-countdown',
+        async () => {
+            const resp = await fetch(
+                googleCalendarURL(
+                    googleCalendarId,
+                    googleCalendarEventID,
+                    googleCalendarApiKey,
+                ),
+            );
+            if (resp.ok) {
+                const json = await resp.json();
+                return {
+                    start: moment(json.start.dateTime),
+                    end: moment(json.end.dateTime),
+                };
+            }
+            return { start: moment(eventStartString), end: moment(eventEndString) };
+        },
+        {
+            initialData: {
+                start: moment(eventStartString),
+                end: moment(eventEndString),
+            },
+            revalidateOnMount: true,
+        },
+    );
 
     const [countdown, setCountdown] = useState({
         days: 0,
@@ -92,7 +91,7 @@ export const LiveCountdown = ({ countdownToDate }) => {
     const calculateCountdownValues = () => {
         const current = moment();
         const currentUnix = current.unix();
-        
+
         const diffTime = currentUnix < times.start.unix() ? times.start.unix() - currentUnix : times.end.unix() - currentUnix;
         const duration = moment.duration(diffTime, 'seconds');
         setCountdown({

--- a/src/components/timeline/timeline.jsx
+++ b/src/components/timeline/timeline.jsx
@@ -44,13 +44,14 @@ export const Timeline = props => {
         googleCalendarId,
     } = data.site.siteMetadata;
 
-    const { data: gcalTimelineData = {} } = useSWR(
+    const { data: gcalTimelineData } = useSWR(
         'calendar-events',
         async () => {
             let out = await fetch(
                 `https://www.googleapis.com/calendar/v3/calendars/${googleCalendarId}/events?key=${googleCalendarApiKey}`
             )
                 .then(resp => {
+                    console.log('I have loaded');
                     if (resp.ok) {
                         return resp.json();
                     } else {
@@ -73,19 +74,25 @@ export const Timeline = props => {
                                 date: moment(event.start.dateTime).format(
                                     'DD/MM/YY'
                                 ),
-                                events: [ev],
+                                events: [event_data],
                             };
                         }
                         return timeline;
                     }, {});
                 })
-                .catch(() => {});
+                .catch((e) => {
+                    console.log('error...');
+                    console.log(e);
+                });
+            console.log('Finished....');
+            console.log(out);
             return out;
         },
         {
             initialData: timelineData
         }
     );
+
     const firstLoad = useRef(true);
     const wrapper = useRef(null);
     const track = useRef(null);
@@ -147,7 +154,7 @@ export const Timeline = props => {
     };
 
     useEffect(() => {
-        if (firstLoad.current) {
+        if (true) {
             firstLoad.current = false;
             let timelineDays = Object.keys(gcalTimelineData);
             timelineDays = timelineDays.map((day) => {
@@ -185,7 +192,7 @@ export const Timeline = props => {
             setTrackHeight(maxHeight);
         }
 
-    }, [timelineEvents]);
+    }, [timelineEvents, gcalTimelineData]);
 
     return (
         <div className={style.timeline}>

--- a/src/components/timeline/timeline.jsx
+++ b/src/components/timeline/timeline.jsx
@@ -83,12 +83,11 @@ export const Timeline = props => {
                     console.log('error...');
                     console.error(e);
                 });
-            console.log('Finished....');
-            console.log(out);
             return out;
         },
         {
-            initialData: timelineData
+            initialData: timelineData,
+            revalidateOnMount: true
         }
     );
 
@@ -157,7 +156,6 @@ export const Timeline = props => {
             let timelineDays = Object.keys(gcalTimelineData);
             timelineDays = timelineDays.map((day) => {
                 const { name, date, events } = gcalTimelineData[day];
-                console.log('weekday', name, date, moment(date, 'DD/MM/YY').day())
                 const parsedDate = moment(date, 'DD/MM/YY');
                 const isSameDay = moment().isSame(parsedDate, 'day');
                 if (isSameDay) {
@@ -171,7 +169,6 @@ export const Timeline = props => {
                     date,
                 };
             });
-            console.log(timelineDays)
             setDays(timelineDays);
 
     }, [gcalTimelineData])

--- a/src/components/timeline/timeline.jsx
+++ b/src/components/timeline/timeline.jsx
@@ -44,7 +44,7 @@ export const Timeline = props => {
         googleCalendarId,
     } = data.site.siteMetadata;
 
-    const { data: gcalTimelineData } = useSWR(
+    const { data: gcalTimelineData = {} } = useSWR(
         'calendar-events',
         async () => {
             let out = await fetch(
@@ -104,7 +104,7 @@ export const Timeline = props => {
      */
     const getEventsForDay = ({ today, date }) => {
         const todayDate = today ? moment() : moment(date, 'DD/MM/YY');
-        const daysData = Object.values(timelineData);
+        const daysData = Object.values(gcalTimelineData);
         return daysData.find((day) => todayDate.isSame(moment(day.date, 'DD/MM/YY'), 'day'))?.events || [];
     };
 
@@ -149,13 +149,13 @@ export const Timeline = props => {
     useEffect(() => {
         if (firstLoad.current) {
             firstLoad.current = false;
-            let timelineDays = Object.keys(timelineData);
+            let timelineDays = Object.keys(gcalTimelineData);
             timelineDays = timelineDays.map((day) => {
-                const { name, date, events } = timelineData[day];
+                const { name, date, events } = gcalTimelineData[day];
                 const parsedDate = moment(date, 'DD/MM/YY');
                 const isSameDay = moment().isSame(parsedDate, 'day');
                 if (isSameDay) {
-                    setActiveDay(timelineData[day]);
+                    setActiveDay(gcalTimelineData[day]);
                     setTimelineEvents(events);
                 }
                 return {

--- a/src/components/timeline/timeline.jsx
+++ b/src/components/timeline/timeline.jsx
@@ -51,7 +51,6 @@ export const Timeline = props => {
                 `https://www.googleapis.com/calendar/v3/calendars/${googleCalendarId}/events?key=${googleCalendarApiKey}`
             )
                 .then(resp => {
-                    console.log('I have loaded');
                     if (resp.ok) {
                         return resp.json();
                     } else {
@@ -62,7 +61,7 @@ export const Timeline = props => {
                     return json.items.reduce((timeline, event) => {
                         const event_data = {
                             name: event.summary,
-                            time: moment(event.start.dateTime).format('hh:mm'),
+                            time: moment(event.start.dateTime).format('HH:MM'),
                             owner: event.summary,
                         };
                         const day = moment(event.start.dateTime).format('dddd');
@@ -82,7 +81,7 @@ export const Timeline = props => {
                 })
                 .catch((e) => {
                     console.log('error...');
-                    console.log(e);
+                    console.error(e);
                 });
             console.log('Finished....');
             console.log(out);
@@ -93,7 +92,6 @@ export const Timeline = props => {
         }
     );
 
-    const firstLoad = useRef(true);
     const wrapper = useRef(null);
     const track = useRef(null);
 
@@ -117,6 +115,7 @@ export const Timeline = props => {
 
     const renderTimelineItem = (events) => useMemo(() => events.map(({ name, time, owner }) => {
         if (activeDay) {
+        console.log('render event', name, time, owner)
             const { date } = activeDay;
             const currentDay = moment(activeDay.date, 'DD/MM/YY');
             const currentTime = currentDay.startOf('hour');
@@ -142,6 +141,7 @@ export const Timeline = props => {
         if (state === 'inactive') {
             const newDays = days.map((d) => {
                 if (d.key === key) {
+                    setActiveDay(d)
                     d.state = 'active';
                 } else {
                     d.state = 'inactive';
@@ -154,11 +154,10 @@ export const Timeline = props => {
     };
 
     useEffect(() => {
-        if (true) {
-            firstLoad.current = false;
             let timelineDays = Object.keys(gcalTimelineData);
             timelineDays = timelineDays.map((day) => {
                 const { name, date, events } = gcalTimelineData[day];
+                console.log('weekday', name, date, moment(date, 'DD/MM/YY').day())
                 const parsedDate = moment(date, 'DD/MM/YY');
                 const isSameDay = moment().isSame(parsedDate, 'day');
                 if (isSameDay) {
@@ -172,14 +171,12 @@ export const Timeline = props => {
                     date,
                 };
             });
+            console.log(timelineDays)
             setDays(timelineDays);
 
-            if (wrapper.current) {
-                const now = moment().hour();
-                wrapper.current.scroll(now * spaceBetweenPoints, 0);
-            }
-        }
+    }, [gcalTimelineData])
 
+    useEffect(() => {
         if (track.current) {
             let maxHeight = 0;
             const children = Array.from(track.current.children);
@@ -191,8 +188,12 @@ export const Timeline = props => {
             })
             setTrackHeight(maxHeight);
         }
+            if (wrapper.current) {
+                const now = moment().hour();
+                wrapper.current.scroll(now * spaceBetweenPoints, 0);
+            }
 
-    }, [timelineEvents, gcalTimelineData]);
+    }, [timelineEvents]);
 
     return (
         <div className={style.timeline}>

--- a/src/components/timeline/timeline.jsx
+++ b/src/components/timeline/timeline.jsx
@@ -28,6 +28,7 @@ import { timelineData } from '../../data/timeline';
  * @constructor
  */
 export const Timeline = props => {
+    const host_regex = /(?<=Host: )(.*$)/m;
     const data = useStaticQuery(graphql`
         query TimelineQuery {
             site {
@@ -59,10 +60,12 @@ export const Timeline = props => {
                 })
                 .then(json => {
                     return json.items.reduce((timeline, event) => {
+                        const m = host_regex.exec(event.description)
+                        const time = moment(event.start.dateTime, 'YYYY-MM-DDTHH:mm:ssZZ').format('HH:mm');
                         const event_data = {
                             name: event.summary,
-                            time: moment(event.start.dateTime).format('HH:MM'),
-                            owner: event.summary,
+                            time,
+                            owner: m !== null ? m[0] : event.summary,
                         };
                         const day = moment(event.start.dateTime).format('dddd');
                         if (day in timeline) {
@@ -114,7 +117,6 @@ export const Timeline = props => {
 
     const renderTimelineItem = (events) => useMemo(() => events.map(({ name, time, owner }) => {
         if (activeDay) {
-        console.log('render event', name, time, owner)
             const { date } = activeDay;
             const currentDay = moment(activeDay.date, 'DD/MM/YY');
             const currentTime = currentDay.startOf('hour');

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -1,0 +1,11 @@
+{
+    "meta": {
+        "title": "HackTheMidlands",
+        "eventStart": "2020-10-22 17:00+01",
+        "eventEnd": "2020-10-25 19:00+00",
+        "countdownCalendarId": "4980k4aspujqrjcjl19p4v6o7g@group.calendar.google.com",
+        "googleCalendarId": "calendar@hackthemidlands.com",
+        "googleCalendarApiKey": "AIzaSyC7Kbx5FmV_AQT_PAHk70wkGojHUagM3ds",
+        "googleCalendarEventID": "5ht3ma5k33ekkf7jinvb7apm8d"
+    }
+}

--- a/src/data/site.json
+++ b/src/data/site.json
@@ -5,7 +5,7 @@
         "eventEnd": "2020-10-25 19:00+00",
         "countdownCalendarId": "4980k4aspujqrjcjl19p4v6o7g@group.calendar.google.com",
         "googleCalendarId": "calendar@hackthemidlands.com",
-        "googleCalendarApiKey": "AIzaSyC7Kbx5FmV_AQT_PAHk70wkGojHUagM3ds",
+        "googleCalendarApiKey": "AIzaSyAsr1gbJafUFaVkhh8oL_Sey6YyHMsMsdE",
         "googleCalendarEventID": "5ht3ma5k33ekkf7jinvb7apm8d"
     }
 }

--- a/src/pages/live.js
+++ b/src/pages/live.js
@@ -74,7 +74,7 @@ const Live = (props) => {
 
             <LiveNavBar />
 
-            <LivePageHeader />
+            {/*<LivePageHeader />*/}
 
             <section className={style.section}>
                 <LogoStrip logos={companyLogos} />


### PR DESCRIPTION
- [x] fetch times for countdown from google calendar
- [x] count down to end of event after start
- [ ] change text when counting down to end
- [x] fetch timeline events from google calendar
- [x] fix delay on fetching calendar events
- [ ] sort days of the week in the right order (timeline)
- [x] add 'owner' details instead of duplicating summary